### PR TITLE
Moved hull functions and tests over from thermofitting

### DIFF
--- a/tests/geometry/binary.py
+++ b/tests/geometry/binary.py
@@ -1,0 +1,64 @@
+import pytest
+import numpy as np
+from scipy.spatial import ConvexHull
+
+
+@pytest.fixture
+def binary_points():
+    return np.array(
+        [
+            [5, 5],
+            [1, 3],
+            [5, 0],
+            [1, 8],
+            [7, 7],
+            [1, 1],
+            [3, 8],
+            [9, 7],
+            [6, 6],
+            [4, 3],
+            [3, 9],
+            [5, 9],
+            [4, 2],
+            [2, 9],
+            [7, 3],
+            [8, 4],
+            [9, 2],
+            [5, 7],
+            [6, 4],
+            [8, 8],
+            [6, 5],
+            [6, 9],
+            [5, 2],
+            [8, 3],
+            [0, 8],
+        ],
+        dtype=float,
+    )
+
+
+@pytest.fixture
+def binary_lower_hull_vertex_indices():
+    return np.array([2, 5, 16, 24])
+
+
+@pytest.fixture
+def binary_lower_hull_simplices():
+    return np.array([[24, 5], [5, 2], [2, 16]])
+
+
+@pytest.fixture
+def binary_hull(binary_points):
+    return ConvexHull(binary_points)
+
+
+@pytest.fixture
+def binary_lower_hull_simplex_indices(binary_hull, binary_lower_hull_simplices):
+    return np.array(
+        [
+            [frozenset(simplex) for simplex in binary_hull.simplices].index(
+                frozenset(known_simplex)
+            )
+            for known_simplex in binary_lower_hull_simplices
+        ]
+    )

--- a/tests/geometry/test_hull.py
+++ b/tests/geometry/test_hull.py
@@ -1,0 +1,102 @@
+import pytest
+import numpy as np
+from scipy.spatial import ConvexHull
+from thermocore.geometry.hull import (
+    barycentric_coordinates,
+    lower_hull,
+    simplex_energy_equation_matrix,
+    lower_hull_simplex_containing,
+)
+from tests.geometry.binary import (
+    binary_points,
+    binary_lower_hull_vertex_indices,
+    binary_lower_hull_simplices,
+    binary_hull,
+    binary_lower_hull_simplex_indices,
+)
+
+
+def test_lower_hull_binary(
+    binary_points,
+    binary_hull,
+    binary_lower_hull_vertex_indices,
+    binary_lower_hull_simplices,
+):
+    """Tests lower_hull for binary data."""
+    lower_hull_vertex_indices, lower_hull_simplex_indices = lower_hull(binary_hull)
+    assert set(lower_hull_vertex_indices) == set(binary_lower_hull_vertex_indices)
+    simplices_result_set = [
+        frozenset(simplex)
+        for simplex in binary_hull.simplices[lower_hull_simplex_indices]
+    ]
+    simplices_expected_set = [
+        frozenset(simplex) for simplex in binary_lower_hull_simplices
+    ]
+    assert simplices_result_set == simplices_expected_set
+
+
+def test_simplex_energy_equation_matrix_binary(
+    binary_hull, binary_lower_hull_simplex_indices
+):
+    """Tests simplex_energy_equation_matrix for binary data, on lower hull simplices."""
+    equation_matrix_result = simplex_energy_equation_matrix(
+        binary_hull, binary_lower_hull_simplex_indices
+    )
+    equation_matrix_expected = np.array([[-7, 8], [-0.25, 1.25], [0.5, -2.5]])
+    assert np.allclose(equation_matrix_result, equation_matrix_expected)
+
+
+def test_energy_equation_matrix_binary_vertical(binary_hull):
+    """Tests simplex_energy_equation_matrix for binary data, on all simplices.
+    Should encounter error due to vertical simplex."""
+    with pytest.raises(ValueError):
+        simplex_energy_equation_matrix(binary_hull, range(len(binary_hull.simplices)))
+
+
+def test_lower_hull_simplex_containing_binary(
+    binary_hull, binary_lower_hull_simplex_indices
+):
+    """Tests lower_hull_simplex_containing for binary data."""
+    test_points = np.array([0, 0.5, 1, 3, 5, 7.5, 9])
+    possible_simplex_indices = [
+        [binary_lower_hull_simplex_indices[i] for i in possible]
+        for possible in [[0], [0], [0, 1], [1], [1, 2], [2], [2]]
+    ]
+    expected_energies = [8, 4.5, 1, 0.5, 0, 1.25, 2]
+    result = lower_hull_simplex_containing(test_points, binary_hull)
+    result_indices_provided = lower_hull_simplex_containing(
+        test_points, binary_hull, binary_lower_hull_simplex_indices
+    )
+    assert np.array_equal(result[0], result_indices_provided[0])
+    assert np.array_equal(result[1], result_indices_provided[1])
+    for i in range(len(test_points)):
+        assert result[0][i] in possible_simplex_indices[i]
+        assert np.isclose(result[1][i], expected_energies[i])
+
+
+def test_lower_hull_simplex_containing_binary_out_of_bounds(binary_hull):
+    """Tests lower_hull_simplex_containing for binary data with points
+    that are out of bounds, which should cause errors."""
+    test_points_low = np.array([-0.5])
+    with pytest.raises(ValueError):
+        lower_hull_simplex_containing(test_points_low, binary_hull)
+    test_points_high = np.array([9.5])
+    with pytest.raises(ValueError):
+        lower_hull_simplex_containing(test_points_high, binary_hull)
+
+
+def test_barycentric_coordinates_1D():
+    """Tests barycentric_coordinates for points in one dimension."""
+    for a in np.linspace(-2, 2, 10):
+        for d in np.linspace(1, 5, 10):
+            b = a + d
+            for p in np.linspace(a, b, 10):
+                coordinates = barycentric_coordinates(
+                    np.array([p]), np.array([[a], [b]])
+                )
+                x1 = 1 - (p - a) / (b - a)
+                x2 = 1 - x1
+                assert np.allclose(coordinates, np.array([x1, x2]))
+
+
+# TODO: Tests for ternary data

--- a/thermocore/geometry/hull.py
+++ b/thermocore/geometry/hull.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+from collections.abc import Sequence
+import numpy as np
+from scipy.optimize import linprog
+from scipy.spatial import ConvexHull
+
+
+def barycentric_coordinates(
+    point: numpy.ndarray, vertices: numpy.ndarray
+) -> numpy.ndarray:
+    """Returns the barycentric coordinates of `point` with respect to the simplex defined by `vertices`.
+
+    TODO: Take multiple points?
+
+    Parameters
+    ----------
+    point : numpy.ndarray of floats, shape (n_dim,)
+        Point to get barycentric coordinates for.
+    vertices : numpy.ndarray of floats, shape (n_dim + 1, n_dim)
+        Vertices of reference simplex for the barycentric coordinates.
+
+    Returns
+    -------
+    numpy.ndarray of floats, shape (n_dim + 1,)
+        Barycentric coordinates of `point`.
+    """
+    # Check dimensions
+    n_dim = len(point)
+    if not vertices.shape[0] == n_dim + 1:
+        raise ValueError("Number of vertices provided inconsistent with dimension.")
+
+    if not vertices.shape[1] == n_dim:
+        raise ValueError("Point and vertex dimensions inconsistent.")
+
+    # Find barycentric coordinates
+    H = np.vstack((vertices.transpose(), np.ones((1, n_dim + 1))))
+    H_inv = np.linalg.inv(H)
+    return H_inv @ np.append(point, 1)
+
+
+def inside_convex_hull(points: numpy.ndarray, test_points: numpy.ndarray) -> list[bool]:
+    """Returns a list of booleans indicating whether each point in `test_points` is inside the convex hull of `points`.
+
+    This does not require finding the convex hull of `points`, only determining whether each of `test_points`
+    can be expressed as a convex combination of `points`, which can be done using linear programming.
+
+    For a single test point p and the points x_i, we check whether there exist coefficients a_i such that
+    p = a_1*x_1 + a_2*x_2 + ... + a_n*x_n, where the a_i are non-negative and sum to 1.
+
+    Adapted from: https://stackoverflow.com/a/43564754
+
+    Parameters
+    ---------
+    points : numpy.ndarray of floats, shape (n_points, n_dim)
+        Points defining the convex hull.
+    test_points : numpy.ndarray of floats, shape (n_test_points, n_dim)
+        Points to be tested for whether they are inside the convex hull.
+
+    Returns
+    -------
+    list[bool]
+        Booleans indicating whether each test point is inside the convex hull.
+    """
+    n_points = len(points)
+    c = np.zeros(n_points)
+    A = np.vstack((points.transpose(), np.ones((1, n_points))))
+    return [linprog(c, A_eq=A, b_eq=np.append(p, 1.0)).success for p in test_points]
+
+
+def full_hull(
+    compositions: numpy.ndarray, energies: numpy.ndarray
+) -> scipy.spatial.ConvexHull:
+    """Returns the full convex hull of the points specified by appending `energies` to `compositions`.
+
+    Parameters
+    ----------
+    compositions: numpy.ndarray of floats, shape (n_points, n_composition_axes)
+        Compositions of points.
+    energies: numpy.ndarray of floats, shape (n_points,)
+        Energies of points.
+    Returns
+    -------
+    scipy.spatial.ConvexHull
+        Convex hull of points.
+    """
+    return ConvexHull(np.hstack((compositions, energies[:, np.newaxis])))
+
+
+def lower_hull(
+    convex_hull: scipy.spatial.ConvexHull, tolerance: float = 1e-14
+) -> tuple[numpy.ndarray, numpy.ndarray]:
+    """Returns the vertices and simplices of the lower convex hull (with respect to the last coordinate) of `convex_hull`.
+
+    Parameters
+    ----------
+    convex_hull : scipy.spatial.ConvexHull
+        Complete convex hull object.
+    tolerance : float, optional
+        Tolerance for identifying lower hull simplices (default is 1e-14).
+
+    Returns
+    -------
+    lower_hull_vertex_indices : numpy.ndarray of ints, shape (n_vertices,)
+        Indices of points forming the vertices of the lower convex hull.
+    lower_hull_simplex_indices : numpy.ndarray of ints, shape (n_simplices,)
+        Indices of simplices (within `convex_hull.simplices`) forming the facets of the lower convex hull.
+    """
+    # Find lower hull simplices
+    lower_hull_simplex_indices = (-convex_hull.equations[:, -2] > tolerance).nonzero()[
+        0
+    ]
+    if lower_hull_simplex_indices.size == 0:
+        raise RuntimeError("No lower hull simplices found.")
+
+    # Gather lower hull vertices from simplices
+    lower_hull_vertex_indices = np.unique(
+        np.ravel(convex_hull.simplices[lower_hull_simplex_indices])
+    )
+    return lower_hull_vertex_indices, lower_hull_simplex_indices
+
+
+def simplex_energy_equation_matrix(
+    convex_hull: scipy.spatial.ConvexHull,
+    simplex_indices: Sequence[int],
+    tolerance: float = 1e-14,
+) -> numpy.ndarray:
+    """Returns a matrix that encodes the energy equation of each requested convex hull simplex.
+
+    Each row in the matrix corresponds to a simplex (as specified by `simplex_indices`).
+
+    Each simplex is described by a hyperplane. For example, in a 3d composition space
+        a1*x1 + a2*x2 + a3*x3 + b*e + c = 0
+    where x1, x2, x3 are the composition variables and e is the energy.
+
+    Solving for e yields
+        e = -(a1*x1 + a2*x2 + a3*x3 + c)/b
+
+    The corresponding row in the equation matrix is then (-a1/b, -a2/b, -a3/b, -c/b),
+    such that multiplying with the column vector (x1, x2, x3, 1) yields e.
+
+    Parameters
+    ----------
+    convex_hull : scipy.spatial.ConvexHull
+        Complete convex hull object. Last coordinate of each point is assumed to be energy.
+    simplex_indices : Sequence[int]
+        Indices of simplices (within `convex_hull.simplices`) to include in matrix.
+    tolerance : float, optional
+        Tolerance for checking for vertical hull facets with b close to 0 (default is 1e-14).
+
+    Returns
+    -------
+    numpy.ndarray of floats, shape (n_simplex_indices, n_composition_axes + 1)
+        Matrix of simplex energy equations.
+    """
+    # Check for vertical simplices (b = 0 case)
+    vertical_simplex_indices = np.array(simplex_indices)[
+        (np.abs(convex_hull.equations[simplex_indices, -2]) < tolerance).nonzero()[0]
+    ]
+    if not vertical_simplex_indices.size == 0:
+        raise ValueError(
+            f"Vertical hull simplex encountered: Simplex index {','.join(map(str, vertical_simplex_indices))}."
+        )
+
+    # Form and return equation matrix
+    return (
+        -np.delete(convex_hull.equations[simplex_indices, :], -2, axis=1)
+        / convex_hull.equations[simplex_indices, -2][:, np.newaxis]
+    )
+
+
+def lower_hull_simplex_containing(
+    compositions: numpy.ndarray,
+    convex_hull: scipy.spatial.ConvexHull,
+    lower_hull_simplex_indices: Sequence[int] = None,
+    tolerance: float = 1e-14,
+) -> tuple[numpy.ndarray, numpy.ndarray]:
+    """Returns the lower convex hull simplices of `convex_hull` containing the points in composition space specified by `compositions`, and the corresponding energies.
+
+    For points incident with multiple simplices, one of the simplices is chosen arbitrarily.
+
+    Parameters
+    ----------
+    compositions : numpy.ndarray of floats, shape (n_points, n_composition_axes)
+        Compositions of points to find containing simplices for. If a 1D array is provided, it is assumed to be a column (multiple points, one composition axis).
+    convex_hull : scipy.spatial.ConvexHull
+        Complete convex hull object. Last coordinate of each point is assumed to be energy.
+    lower_hull_simplex_indices : Sequence[int], optional
+        Indices of lower hull simplices (within `convex_hull.simplices`), if known.
+    tolerance : float, optional
+        Tolerance for identifying lower hull simplices (default is 1e-14).
+
+    Returns
+    -------
+    simplex_indices : numpy.ndarray of ints, shape (n_points,)
+        Indices of simplices (within `convex_hull.simplices`) containing each point.
+    energies : numpy.ndarray of floats, shape (n_points,)
+        Energy values of points specified by `compositions` on their respective simplices.
+    """
+    if lower_hull_simplex_indices is None:
+        lower_hull_simplex_indices = lower_hull(convex_hull, tolerance=tolerance)[1]
+
+    # Promote 1D composition array to 2D array, if necessary
+    if compositions.ndim == 1:
+        compositions = compositions[:, np.newaxis]
+
+    # Check that matrices are compatible with one another
+    hull_composition_dimension = convex_hull.points.shape[1] - 1
+    if not compositions.shape[1] == hull_composition_dimension:
+        raise ValueError(
+            f"Composition dimensions of input points and hull points differ: {compositions.shape[1]} vs {hull_composition_dimension}."
+        )
+
+    # Check composition bounds for input points
+    # TODO: Should maybe use lower hull vertices rather than convex_hull.vertices in case of tolerance issues
+    out_of_bounds = ~np.array(
+        inside_convex_hull(convex_hull.points[convex_hull.vertices, :-1], compositions)
+    )
+    out_of_bounds_point_indices = out_of_bounds.nonzero()[0]
+    if not out_of_bounds_point_indices.size == 0:
+        raise ValueError(
+            f"Point outside of hull composition bounds encountered: Point index {','.join(map(str, out_of_bounds_point_indices))}."
+        )
+
+    # Form equation matrix and multiply with compositions
+    lower_hull_equation_matrix = simplex_energy_equation_matrix(
+        convex_hull, lower_hull_simplex_indices, tolerance=tolerance
+    )
+    configuration_simplex_energies = lower_hull_equation_matrix @ np.vstack(
+        [compositions.transpose(), np.ones(compositions.shape[0])]
+    )
+
+    # Identify and extract correct simplices, energies
+    maximum_energy_simplex_indices = np.argmax(configuration_simplex_energies, axis=0)
+    simplex_indices = lower_hull_simplex_indices[maximum_energy_simplex_indices]
+    energies = np.take_along_axis(
+        configuration_simplex_energies,
+        maximum_energy_simplex_indices[np.newaxis, :],
+        axis=0,
+    )[0]
+    return simplex_indices, energies
+
+
+def lower_hull_energies(
+    compositions: numpy.ndarray,
+    convex_hull: scipy.spatial.ConvexHull,
+    lower_hull_simplex_indices: Sequence[int] = None,
+    tolerance: float = 1e-14,
+) -> numpy.ndarray:
+    """Returns energies of points in composition space specified by `compositions` along the lower hull of `convex_hull`.
+
+    Parameters
+    ----------
+    compositions : numpy.ndarray of floats, shape (n_points, n_composition_axes)
+        Compositions of points to get energies for. If a 1D array is provided, it is assumed to be a column (multiple points, one composition axis).
+    convex_hull : scipy.spatial.ConvexHull
+        Complete convex hull object. Last coordinate of each point is assumed to be energy.
+    lower_hull_simplex_indices : Sequence[int], optional
+        Indices of lower hull simplices (within `convex_hull.simplices`), if known.
+    tolerance : float, optional
+        Tolerance for identifying lower hull simplices (default is 1e-14).
+
+    Returns
+    -------
+    numpy.ndarray of floats, shape (n_points,)
+        Energies of points.
+    """
+    return lower_hull_simplex_containing(
+        compositions, convex_hull, lower_hull_simplex_indices, tolerance=tolerance
+    )[1]
+
+
+def lower_hull_distances(
+    compositions: numpy.ndarray,
+    energies: numpy.ndarray,
+    convex_hull: scipy.spatial.ConvexHull = None,
+    lower_hull_simplex_indices: Sequence[int] = None,
+    tolerance: float = 1e-14,
+) -> numpy.ndarray:
+    """Returns hull distances (energy above lower convex hull of `convex_hull`) of points in energy-composition space specified by `compositions` and `energies`.
+
+    If `convex_hull` is omitted, it will be calculated from `compositions` and `energies`.
+
+    Parameters
+    ----------
+    compositions : numpy.ndarray of floats, shape (n_points, n_composition_axes)
+        Compositions of points to get hull distances for. If a 1D array is provided, it is assumed to be a column (multiple points, one composition axis).
+    energies : numpy.ndarray of floats, shape (n_points,)
+        Energies of points to get hull distances for.
+    convex_hull : scipy.spatial.ConvexHull, optional
+        Complete convex hull object. Last coordinate of each point is assumed to be energy.
+    lower_hull_simplex_indices : Sequence[int], optional
+        Indices of lower hull simplices (within `convex_hull.simplices`), if known.
+    tolerance : float, optional
+        Tolerance for identifying lower hull simplices (default is 1e-14).
+
+    Returns
+    -------
+    numpy.ndarray of floats, shape (n_points,)
+        Hull distances of points.
+    """
+    if convex_hull is None:
+        convex_hull = full_hull(compositions, energies)
+        lower_hull_simplex_indices = None
+    return energies - lower_hull_energies(
+        compositions, convex_hull, lower_hull_simplex_indices, tolerance=tolerance
+    )


### PR DESCRIPTION
It might be good to move more general functions like `barycentric_coordinates` to a separate file, but I put everything in `hull.py` for now.